### PR TITLE
fix(windows): Generate .csproj with unique UUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "mkdirp": "^0.5.1",
     "param-case": "^2.1.0",
     "pascal-case": "^2.0.0",
-    "path-exists": "^3.0.0"
+    "path-exists": "^3.0.0",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^3.1.0",

--- a/templates/general.js
+++ b/templates/general.js
@@ -32,7 +32,7 @@ module.exports = [{
   	\`\`\`
       compile project(':${moduleName}')
   	\`\`\`
-`;
+`     ;
     }
 
     if (platforms.indexOf('windows') >= 0) {
@@ -44,7 +44,7 @@ module.exports = [{
 2. Open up your \`MainPage.cs\` app
   - Add \`using Cl.Json.${name};\` to the usings at the top of the file
   - Add \`new ${name}Package()\` to the \`List<IReactPackage>\` returned by the \`Packages\` method
-      `;
+`     ;
     }
 
     return `
@@ -73,7 +73,14 @@ ${name};
   },
 }, {
   name: () => 'package.json',
-  content: ({ moduleName }) => `
+  content: ({ moduleName, platforms }) => {
+    var dependencies = '"react-native": "^0.29.0"';
+    if (platforms.indexOf('windows') >= 0) {
+      dependencies += `,
+    "react-native-windows": "^0.29.0"
+`       ;
+    }
+    return `
 {
   "name": "${moduleName}",
   "version": "1.0.0",
@@ -88,10 +95,11 @@ ${name};
   "author": "",
   "license": "",
   "peerDependencies": {
-    "react-native": "^0.29.0"
+    ${dependencies}
   }
 }
-`,
+`   ;
+  }
 }, {
   name: () => 'index.js',
   content: ({ name }) => `

--- a/templates/windows.js
+++ b/templates/windows.js
@@ -1,15 +1,15 @@
-/* eslint max-len: 0 */
-
+﻿/* eslint max-len: 0 */
+const uuid = require('uuid').v1().toUpperCase();
 module.exports = platform => [{
   name: ({ name }) => `${platform}/${name}.sln`,
-  content: ({ name }) => `
-Microsoft Visual Studio Solution File, Format Version 12.00
+  content: ({ name }) => 
+`Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "${name}", "${name}\${name}.csproj", "{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "${name}", "${name}\\${name}.csproj", "{${uuid}}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactNative", "..\node_modules\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj", "{C7673AD5-E3AA-468C-A5FD-FA38154E205C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactNative", "..\\node_modules\\react-native-windows\\ReactWindows\\ReactNative\\ReactNative.csproj", "{C7673AD5-E3AA-468C-A5FD-FA38154E205C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,30 +27,30 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|ARM.ActiveCfg = Debug|ARM
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|ARM.Build.0 = Debug|ARM
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x64.ActiveCfg = Debug|x64
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x64.Build.0 = Debug|x64
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x86.ActiveCfg = Debug|x86
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Debug|x86.Build.0 = Debug|x86
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|Any CPU.ActiveCfg = Development|Any CPU
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|Any CPU.Build.0 = Development|Any CPU
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|ARM.ActiveCfg = Development|ARM
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|ARM.Build.0 = Development|ARM
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x64.ActiveCfg = Development|x64
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x64.Build.0 = Development|x64
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x86.ActiveCfg = Development|x86
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Development|x86.Build.0 = Development|x86
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|ARM.ActiveCfg = Release|ARM
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|ARM.Build.0 = Release|ARM
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x64.ActiveCfg = Release|x64
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x64.Build.0 = Release|x64
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x86.ActiveCfg = Release|x86
-		{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}.Release|x86.Build.0 = Release|x86
+		{${uuid}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{${uuid}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{${uuid}}.Debug|ARM.ActiveCfg = Debug|ARM
+		{${uuid}}.Debug|ARM.Build.0 = Debug|ARM
+		{${uuid}}.Debug|x64.ActiveCfg = Debug|x64
+		{${uuid}}.Debug|x64.Build.0 = Debug|x64
+		{${uuid}}.Debug|x86.ActiveCfg = Debug|x86
+		{${uuid}}.Debug|x86.Build.0 = Debug|x86
+		{${uuid}}.Development|Any CPU.ActiveCfg = Development|Any CPU
+		{${uuid}}.Development|Any CPU.Build.0 = Development|Any CPU
+		{${uuid}}.Development|ARM.ActiveCfg = Development|ARM
+		{${uuid}}.Development|ARM.Build.0 = Development|ARM
+		{${uuid}}.Development|x64.ActiveCfg = Development|x64
+		{${uuid}}.Development|x64.Build.0 = Development|x64
+		{${uuid}}.Development|x86.ActiveCfg = Development|x86
+		{${uuid}}.Development|x86.Build.0 = Development|x86
+		{${uuid}}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{${uuid}}.Release|Any CPU.Build.0 = Release|Any CPU
+		{${uuid}}.Release|ARM.ActiveCfg = Release|ARM
+		{${uuid}}.Release|ARM.Build.0 = Release|ARM
+		{${uuid}}.Release|x64.ActiveCfg = Release|x64
+		{${uuid}}.Release|x64.Build.0 = Release|x64
+		{${uuid}}.Release|x86.ActiveCfg = Release|x86
+		{${uuid}}.Release|x86.Build.0 = Release|x86
 		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C7673AD5-E3AA-468C-A5FD-FA38154E205C}.Debug|ARM.ActiveCfg = Debug|ARM
@@ -83,8 +83,8 @@ EndGlobal
   `,
 }, {
   name: () => `${platform}/.gitignore`,
-  content: () => `
-*AppPackages*
+  content: () => 
+`*AppPackages*
 *BundleArtifacts*
 *ReactAssets*
 
@@ -165,8 +165,8 @@ packages/
 `,
 }, {
   name: ({ name }) => `${platform}/${name}/project.json`,
-  content: () => `
-{
+  content: () => 
+`{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
   },
@@ -185,14 +185,14 @@ packages/
 `,
 }, {
   name: ({ name }) => `${platform}/${name}/${name}.csproj`,
-  content: ({ name }) => `
-<?xml version="1.0" encoding="utf-8"?>
+  content: ({ name }) => 
+`<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\\$(MSBuildToolsVersion)\\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{4ACDD44C-E556-423E-BD74-B4CEF3E67FF0}</ProjectGuid>
+    <ProjectGuid>{${uuid}}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>${name}</RootNamespace>
@@ -204,17 +204,17 @@ packages/
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ReactWindowsRoot>..\..\node_modules</ReactWindowsRoot>
+    <ReactWindowsRoot>..\\..\\node_modules</ReactWindowsRoot>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' != 'Development'">
-    <ReactWindowsRoot>..\..</ReactWindowsRoot>
+    <ReactWindowsRoot>..\\..</ReactWindowsRoot>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\\Debug\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -223,7 +223,7 @@ packages/
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\\Release\\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -231,7 +231,7 @@ packages/
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>bin\\x86\\Debug\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <DebugType>full</DebugType>
@@ -241,7 +241,7 @@ packages/
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>
-    <OutputPath>bin\x86\Release\</OutputPath>
+    <OutputPath>bin\\x86\\Release\\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
@@ -253,7 +253,7 @@ packages/
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <OutputPath>bin\\ARM\\Debug\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <DebugType>full</DebugType>
@@ -263,7 +263,7 @@ packages/
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
-    <OutputPath>bin\ARM\Release\</OutputPath>
+    <OutputPath>bin\\ARM\\Release\\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
@@ -275,7 +275,7 @@ packages/
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
+    <OutputPath>bin\\x64\\Debug\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <DebugType>full</DebugType>
@@ -285,7 +285,7 @@ packages/
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
-    <OutputPath>bin\x64\Release\</OutputPath>
+    <OutputPath>bin\\x64\\Release\\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
@@ -299,13 +299,13 @@ packages/
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\\AssemblyInfo.cs" />
     <Compile Include="${name}Module.cs" />
     <Compile Include="${name}Package.cs" />
-    <EmbeddedResource Include="Properties\${name}.rd.xml" />
+    <EmbeddedResource Include="Properties\\${name}.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(ReactWindowsRoot)\react-native-windows\ReactWindows\ReactNative\ReactNative.csproj">
+    <ProjectReference Include="$(ReactWindowsRoot)\\react-native-windows\\ReactWindows\\ReactNative\\ReactNative.csproj">
       <Project>{c7673ad5-e3aa-468c-a5fd-fa38154e205c}</Project>
       <Name>ReactNative</Name>
     </ProjectReference>
@@ -315,7 +315,7 @@ packages/
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Development\</OutputPath>
+    <OutputPath>bin\\Development\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>
@@ -326,7 +326,7 @@ packages/
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Development\</OutputPath>
+    <OutputPath>bin\\x86\\Development\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
@@ -338,7 +338,7 @@ packages/
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|ARM'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\ARM\Development\</OutputPath>
+    <OutputPath>bin\\ARM\\Development\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
@@ -350,7 +350,7 @@ packages/
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Development|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Development\</OutputPath>
+    <OutputPath>bin\\x64\\Development\\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
@@ -360,7 +360,7 @@ packages/
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\\Microsoft\\WindowsXaml\\v$(VisualStudioVersion)\\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -372,8 +372,8 @@ packages/
 `,
 }, {
   name: ({ name }) => `${platform}/${name}/${name}Module.cs`,
-  content: ({ name, namespace }) => `
-using ReactNative.Bridge;
+  content: ({ name, namespace }) => 
+`using ReactNative.Bridge;
 using System;
 using System.Collections.Generic;
 using Windows.ApplicationModel.Core;
@@ -409,8 +409,8 @@ namespace ${namespace}.${name}
 `,
 }, {
   name: ({ name }) => `${platform}/${name}/${name}Package.cs`,
-  content: ({ name, namespace }) => `
-using ReactNative.Bridge;
+  content: ({ name, namespace }) => 
+`using ReactNative.Bridge;
 using ReactNative.Modules.Core;
 using ReactNative.UIManager;
 using System;
@@ -465,9 +465,9 @@ namespace ${namespace}.${name}
 }
 `,
 }, {
-  name: ({ name }) => `${platform}/${name}/${name}/Properties/${name}.rd.xml`,
-  content: ({ name }) => `
-<?xml version="1.0" encoding="utf-8"?>
+  name: ({ name }) => `${platform}/${name}/Properties/${name}.rd.xml`,
+  content: ({ name }) => 
+`<?xml version="1.0" encoding="utf-8"?>
 <!--
     This file contains Runtime Directives, specifications about types your application accesses
     through reflection and other dynamic code patterns. Runtime Directives are used to control the
@@ -497,9 +497,9 @@ namespace ${namespace}.${name}
 </Directives>
 `,
 }, {
-  name: ({ name }) => `${platform}/${name}/${name}/Properties/AssemblyInfo.cs`,
-  content: ({ name }) => `
-using System.Reflection;
+  name: ({ name }) => `${platform}/${name}/Properties/AssemblyInfo.cs`,
+  content: ({ name }) => 
+`using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
Also, now generates a valid library for Windows across the board (fix up issues with `\` characters and other minor tweaks).

Fixes #13