### PR TITLE
make it RN 0.40 compatible

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -30,7 +30,7 @@ end
 
   name: ({ name }) => `${platform}/${name}.h`,
   content: ({ name }) => `
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface ${name} : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
For RN 0.40, headers changed from

`#import "RCTBridgeModule.h"`

to

`#import <React/RCTBridgeModule.h>`

