### PR TITLE
Configure react native android library to use npm installed react-native. 

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -29,7 +29,12 @@ android {
 }
 
 repositories {
-    mavenCentral()
+    mavenLocal()
+    jcenter()
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$projectDir/../../../node_modules/react-native/android"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Because the last released version in Maven Repo is 0.20.1.
see [http://facebook.github.io/react-native/docs/integration-with-existing-apps.html](http://facebook.github.io/react-native/docs/integration-with-existing-apps.html)