### PR TITLE
Remove depreciated createJSModules @ovveride marker

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -90,7 +90,7 @@ public class ${name}Package implements ReactPackage {
       return Arrays.<NativeModule>asList(new ${name}Module(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }

--- a/templates/android.js
+++ b/templates/android.js
@@ -90,7 +90,7 @@ public class ${name}Package implements ReactPackage {
       return Arrays.<NativeModule>asList(new ${name}Module(reactContext));
     }
 
-    // Depreciated RN 0.47
+    // Deprecated from RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }

--- a/templates/android.js
+++ b/templates/android.js
@@ -90,7 +90,7 @@ public class ${name}Package implements ReactPackage {
       return Arrays.<NativeModule>asList(new ${name}Module(reactContext));
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. It's backwards compatible.