### PR TITLE
Fix import in ios template of RCTBridgeModule

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -30,10 +30,10 @@ end
 
   name: ({ name }) => `${platform}/${name}.h`,
   content: ({ name }) => `
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface ${name} : NSObject <RCTBridgeModule>


### PR DESCRIPTION
With a newer version of React Native the way importing changed. This will fix #47 