### PR TITLE
Fix creating valid workspace file

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -57,8 +57,7 @@ RCT_EXPORT_MODULE()
   `,
 }, {
   name: ({ name }) => `${platform}/${name}.xcworkspace/contents.xcworkspacedata`,
-  content: ({ name }) => `// !$*UTF8*$!
-<?xml version="1.0" encoding="UTF-8"?>
+  content: ({ name }) => `<?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
    <FileRef


### PR DESCRIPTION
This will fix the issue described in #35, where the workspace will not open. I double checked the workspace format by one created with CocoaPods.