### PR TITLE
Fix Error: more than one library with package name 'com.reactlibrary'

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -37,9 +37,14 @@ module.exports = ({
     throw new Error('Please specify at least one platform to generate the library.');
   }
 
-  if (prefix === 'RN') {
-    console.warn(`While \`RN\` is the default prefix,
-  it is recommended to customize the prefix.`);
+  if (prefix === DEFAULT_PREFIX) {
+    console.warn(`While \`${DEFAULT_PREFIX}\` is the default prefix,
+      it is recommended to customize the prefix.`);
+  }
+
+  if (packageIdentifier === DEFAULT_PACKAGE_IDENTIFIER) {
+    console.warn(`While \`{DEFAULT_PACKAGE_IDENTIFIER}\` is the default package
+      identifier, it is recommended to customize the package identifier.`);
   }
 
   return Promise.all(templates.filter((template) => {


### PR DESCRIPTION
This kind of prevents issues described in #45.

We should prevent creating Android libraries with the `com.reactlibrary` namespace. If you just search a bit more multiple people ran into the same issue, that library creator didn't understand that they should change the namespace to something different otherwise it will clash with a library also created with `react-native-create-library`. In fact I think we should prevent it from ever creating a library with a default namespace. This PR will just print out an error for now same as if using the default namespace on iOS.