### PR TITLE
Create Podspec in root of library directory and use package.json for Spec details

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -1,28 +1,30 @@
 /* eslint max-len: 0 */
 
 module.exports = platform => [{
-  name: ({ name }) => `${platform}/${name}.podspec`,
-  content: ({ name }) => `
+  name: ({ name }) => `${name}.podspec`,
+  content: ({ name }) => `require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
 Pod::Spec.new do |s|
   s.name         = "${name}"
-  s.version      = "1.0.0"
-  s.summary      = "${name}"
+  s.version      = package["version"]
+  s.summary      = package["description"]
   s.description  = <<-DESC
                   ${name}
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/author/${name}"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
+  s.author       = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/${name}.git", :tag => "master" }
-  s.source_files  = "${name}/**/*.{h,m}"
-  s.requires_arc = true
+  s.source       = { :git => "https://github.com/author/${name}.git", :tag => "#{s.version}" }
 
+  s.source_files = "ios/**/*.{h,m}"
+  s.requires_arc = true
 
   s.dependency "React"
   #s.dependency "others"
-
 end
 
   `,


### PR DESCRIPTION
Podspecs are usually placed at the root of the project. Therefore this PR will move it to the root of the library directory. Furthermore we use the package.json for details and update the path to actually include the library files.