### PR TITLE
Adds Option To Generate ReactNative Example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options:
   --author-name <name>                      The author's name (Default: `Your Name`)
   --author-email <email>                    The author's email (Default: `yourname@email.com`)
   --license <license>                       The license type of this library (Default: `Apache-2.0`)
+  --generate-example <shouldGenerate>       Will generate a RN example project and link the new library to it (Default: `false`)
 ```
 
 ## Programmatic usage
@@ -77,6 +78,7 @@ createLibrary({
   authorName: String, /* The author's name (Default: `Your Name`) */
   authorEmail: String, /* The author's email (Default: `yourname@email.com`) */ 
   license: String, /* The license type of this library (Default: `Apache-2.0`) */
+  generateExample: Boolean, /* Will generate a RN example project and link the new library to it (Default: `false`) */
 }
 ```
 

--- a/command.js
+++ b/command.js
@@ -89,6 +89,5 @@ ${emoji.get('arrow_right')}  To get started type \`cd ./${name}\` and run \`npm 
   }, {
     command: '--generate-example',
     description: 'Generates an example project for iOS and Android and links the library to it',
-    default: 'false',
   }]
 };

--- a/command.js
+++ b/command.js
@@ -18,6 +18,7 @@ module.exports = {
     const authorName = options.authorName;
     const authorEmail = options.authorEmail;
     const license = options.license;
+    const generateExample = options.generateExample;
 
     const beforeCreation = Date.now();
     createLibrary({
@@ -31,7 +32,8 @@ module.exports = {
       githubAccount,
       authorName,
       authorEmail,
-      license
+      license,
+      generateExample,
     }).then(() => {
       console.log(`
 ${emoji.get('books')}  Created library ${name} in \`./${name}\`.
@@ -84,5 +86,9 @@ ${emoji.get('arrow_right')}  To get started type \`cd ./${name}\` and run \`npm 
     command: '--license [license]',
     description: 'The license type (Default: `Apache-2.0`)',
     default: 'Apache-2.0',    
+  }, {
+    command: '--generate-example',
+    description: 'Generates an example project for iOS and Android and links the library to it',
+    default: 'false',
   }]
 };

--- a/lib.js
+++ b/lib.js
@@ -58,17 +58,14 @@ module.exports = ({
       identifier, it is recommended to customize the package identifier.`);
   }
 
-  return Promise
-    .resolve()
+  return createFolder(name)
     .then(() => {
       if (!generateExample) {
-        return
+        return Promise.resolve()
       }
       // Note: The example has to be created first because it will fail if there
       // is already a package.json in the folder in which the command is executed.
-      return createFolder(name).then(() => {
-        execSync('react-native init example', { cwd: './' + name, stdio:'inherit'});
-      });
+      return execSync('react-native init example', { cwd: './' + name, stdio:'inherit'});
     })
     .then(() => {
       return Promise.all(templates.filter((template) => {
@@ -103,7 +100,7 @@ module.exports = ({
     })
     .then(() => {
       if (!generateExample) {
-        return;
+        return Promise.resolve();
       }
       // Adds and links the created library project
       const pathExampleApp = `./${name}/example`;

--- a/lib.js
+++ b/lib.js
@@ -106,9 +106,14 @@ module.exports = ({
         return;
       }
       // Adds and links the created library project
-      const pathExampleApp = './' + name + '/example';
+      const pathExampleApp = `./${name}/example`;
       const options = { cwd: pathExampleApp, stdio:'inherit'};
-      execSync('yarn add file:../', options);
+      try {
+        execSync('yarn add file:../', options);
+      } catch (e) {
+        execSync('npm install ../', options);
+        execSync('npm install', options);
+      }
       execSync('react-native link', options);
     });
 };

--- a/lib.js
+++ b/lib.js
@@ -5,6 +5,7 @@ const paramCase = require('param-case');
 
 const templates = require('./templates');
 const { hasPrefix, createFile, createFolder } = require('./utils');
+const { execSync } = require('child_process');
 
 const DEFAULT_NAME = 'Library';
 const DEFAULT_PREFIX = 'RN';
@@ -16,6 +17,7 @@ const DEFAULT_GITHUB_ACCOUNT = 'github_account'
 const DEFAULT_AUTHOR_NAME = 'Your Name'
 const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com'
 const DEFAULT_LICENSE = 'Apache-2.0'
+const DEFAULT_GENERATE_EXAMPLE = false;
 
 module.exports = ({
   namespace,
@@ -29,6 +31,7 @@ module.exports = ({
   authorName = DEFAULT_AUTHOR_NAME,
   authorEmail = DEFAULT_AUTHOR_EMAIL,
   license = DEFAULT_LICENSE,
+  generateExample = DEFAULT_GENERATE_EXAMPLE,
 }) => {
   if (!overridePrefix) {
     if (hasPrefix(name)) {
@@ -55,34 +58,57 @@ module.exports = ({
       identifier, it is recommended to customize the package identifier.`);
   }
 
-  return Promise.all(templates.filter((template) => {
-    if (template.platform) {
-      return (platforms.indexOf(template.platform) >= 0);
-    }
+  return Promise
+    .resolve()
+    .then(() => {
+      if (!generateExample) {
+        return
+      }
+      // Note: The example has to be created first because it will fail if there
+      // is already a package.json in the folder in which the command is executed.
+      return createFolder(name).then(() => {
+        execSync('react-native init example', { cwd: './' + name, stdio:'inherit'});
+      });
+    })
+    .then(() => {
+      return Promise.all(templates.filter((template) => {
+        if (template.platform) {
+          return (platforms.indexOf(template.platform) >= 0);
+        }
 
-    return true;
-  }).map((template) => {
-    if (!template.name) {
-      return Promise.resolve();
-    }
+        return true;
+      }).map((template) => {
+        if (!template.name) {
+          return Promise.resolve();
+        }
+        const args = {
+          name: `${prefix}${pascalCase(name)}`,
+          moduleName: `${modulePrefix}-${paramCase(name)}`,
+          packageIdentifier,
+          namespace: namespace || pascalCase(name).split(/(?=[A-Z])/).join('.'),
+          platforms,
+          githubAccount,
+          authorName,
+          authorEmail,
+          license,
+        };
 
-    const args = {
-      name: `${prefix}${pascalCase(name)}`,
-      moduleName: `${modulePrefix}-${paramCase(name)}`,
-      packageIdentifier,
-      namespace: namespace || pascalCase(name).split(/(?=[A-Z])/).join('.'),
-      platforms,
-      githubAccount,
-      authorName,
-      authorEmail,
-      license,
-    };
-
-    const filename = path.join(name, template.name(args));
-    const baseDir = filename.split(path.basename(filename))[0];
-
-    return createFolder(baseDir).then(() =>
-      createFile(filename, template.content(args))
-    );
-  }));
+        const filename = path.join(name, template.name(args));
+        var baseDir = filename.split(path.basename(filename))[0];
+        
+        return createFolder(baseDir).then(() =>
+          createFile(filename, template.content(args))
+        );
+      }));
+    })
+    .then(() => {
+      if (!generateExample) {
+        return;
+      }
+      // Adds and links the created library project
+      const pathExampleApp = './' + name + '/example';
+      const options = { cwd: pathExampleApp, stdio:'inherit'};
+      execSync('yarn add file:../', options);
+      execSync('react-native link', options);
+    });
 };


### PR DESCRIPTION
Adds the option `--generate-example` that generate an example project and links the newly created to it. 

This addresses #28. 

Due to `react-native init project_name` not executing in a folder that already contains a `package.json` file, the example is generated first, then all the files are created and last the library is linked to the example. 