### PR TITLE
Adds Support For Generating Maven Package For Android Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Options:
   --namespace <namespace>                   (Windows only!) The namespace for the Windows module
    (Default: The name as PascalCase)
   --platforms <platforms>                   Platforms the library will be created for. (comma separated; default: `ios,android,windows`)
+  --author-github <github_username>         The author's github username
+  --author-name <name>                      The author's name
+  --author-email <email>                    The author's email
 ```
 
 ## Programmatic usage
@@ -69,6 +72,9 @@ createLibrary({
   platforms: Array, /* Platforms the library will be created for. (Default: ['ios', 'android', 'windows']) */
   packageIdentifier: String, /* (Android only!) The package name for the Android module (Default: com.reactlibrary) */
   namespace: String, /* (Windows only!) The namespace for the Windows module (Default: The package identifier as PascalCase, which is `Com.Reactlibrary`) */
+  authorGithub: String, /* The author's github username */
+  authorName: String, /* The author's name */
+  authorEmail: String, /* The author's email */ 
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Options:
   --namespace <namespace>                   (Windows only!) The namespace for the Windows module
    (Default: The name as PascalCase)
   --platforms <platforms>                   Platforms the library will be created for. (comma separated; default: `ios,android,windows`)
-  --author-github <github_username>         The author's github username (Default: `github_account_name`)
+  --github-account <github_account>         The github account where the library is hosted (Default: `github_account`)
   --author-name <name>                      The author's name (Default: `Your Name`)
   --author-email <email>                    The author's email (Default: `yourname@email.com`)
   --license <license>                       The license type of this library (Default: `Apache-2.0`)
@@ -73,7 +73,7 @@ createLibrary({
   platforms: Array, /* Platforms the library will be created for. (Default: ['ios', 'android', 'windows']) */
   packageIdentifier: String, /* (Android only!) The package name for the Android module (Default: com.reactlibrary) */
   namespace: String, /* (Windows only!) The namespace for the Windows module (Default: The package identifier as PascalCase, which is `Com.Reactlibrary`) */
-  authorGithub: String, /* The author's github username (Default: `github_account_name`) */
+  githubAccount: String, /* The github account where the library is hosted (Default: `github_account`) */
   authorName: String, /* The author's name (Default: `Your Name`) */
   authorEmail: String, /* The author's email (Default: `yourname@email.com`) */ 
   license: String, /* The license type of this library (Default: `Apache-2.0`) */

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
   --author-github <github_username>         The author's github username (Default: `github_account_name`)
   --author-name <name>                      The author's name (Default: `Your Name`)
   --author-email <email>                    The author's email (Default: `yourname@email.com`)
+  --license <license>                       The license type of this library (Default: `Apache-2.0`)
 ```
 
 ## Programmatic usage
@@ -75,6 +76,7 @@ createLibrary({
   authorGithub: String, /* The author's github username (Default: `github_account_name`) */
   authorName: String, /* The author's name (Default: `Your Name`) */
   authorEmail: String, /* The author's email (Default: `yourname@email.com`) */ 
+  license: String, /* The license type of this library (Default: `Apache-2.0`) */
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Options:
   --namespace <namespace>                   (Windows only!) The namespace for the Windows module
    (Default: The name as PascalCase)
   --platforms <platforms>                   Platforms the library will be created for. (comma separated; default: `ios,android,windows`)
-  --author-github <github_username>         The author's github username
-  --author-name <name>                      The author's name
-  --author-email <email>                    The author's email
+  --author-github <github_username>         The author's github username (Default: `github_account_name`)
+  --author-name <name>                      The author's name (Default: `Your Name`)
+  --author-email <email>                    The author's email (Default: `yourname@email.com`)
 ```
 
 ## Programmatic usage
@@ -72,9 +72,9 @@ createLibrary({
   platforms: Array, /* Platforms the library will be created for. (Default: ['ios', 'android', 'windows']) */
   packageIdentifier: String, /* (Android only!) The package name for the Android module (Default: com.reactlibrary) */
   namespace: String, /* (Windows only!) The namespace for the Windows module (Default: The package identifier as PascalCase, which is `Com.Reactlibrary`) */
-  authorGithub: String, /* The author's github username */
-  authorName: String, /* The author's name */
-  authorEmail: String, /* The author's email */ 
+  authorGithub: String, /* The author's github username (Default: `github_account_name`) */
+  authorName: String, /* The author's name (Default: `Your Name`) */
+  authorEmail: String, /* The author's email (Default: `yourname@email.com`) */ 
 }
 ```
 

--- a/command.js
+++ b/command.js
@@ -17,6 +17,7 @@ module.exports = {
     const authorGithub = options.authorGithub;
     const authorName = options.authorName;
     const authorEmail = options.authorEmail;
+    const license = options.license;
 
     const beforeCreation = Date.now();
     createLibrary({
@@ -29,7 +30,8 @@ module.exports = {
       overridePrefix,
       authorGithub,
       authorName,
-      authorEmail
+      authorEmail,
+      license
     }).then(() => {
       console.log(`
 ${emoji.get('books')}  Created library ${name} in \`./${name}\`.
@@ -78,5 +80,9 @@ ${emoji.get('arrow_right')}  To get started type \`cd ./${name}\` and run \`npm 
     command: '--author-email [authorEmail]',
     description: 'The author\'s email (Default: `yourname@email.com`)',
     default: 'yourname@email.com',    
+  }, {
+    command: '--license [license]',
+    description: 'The license type (Default: `Apache-2.0`)',
+    default: 'Apache-2.0',    
   }]
 };

--- a/command.js
+++ b/command.js
@@ -14,7 +14,7 @@ module.exports = {
     const namespace = options.namespace;
     const platforms = (options.platforms) ? options.platforms.split(',') : options.platforms;
     const overridePrefix = options.overridePrefix;
-    const authorGithub = options.authorGithub;
+    const githubAccount = options.githubAccount;
     const authorName = options.authorName;
     const authorEmail = options.authorEmail;
     const license = options.license;
@@ -28,7 +28,7 @@ module.exports = {
       platforms,
       namespace,
       overridePrefix,
-      authorGithub,
+      githubAccount,
       authorName,
       authorEmail,
       license
@@ -69,9 +69,9 @@ ${emoji.get('arrow_right')}  To get started type \`cd ./${name}\` and run \`npm 
     description: 'Platforms the library will be created for. (comma separated; default: `ios,android,windows`)',
     default: 'ios,android,windows',
   }, {
-    command: '--author-github [authorGithub]',
-    description: 'The author\'s github name (Default: `github_account_name`)',
-    default: 'github_account_name',    
+    command: '--github-account [githubAccount]',
+    description: 'The github account where the library is hosted (Default: `github_account`)',
+    default: 'github_account',    
   }, {
     command: '--author-name [authorName]',
     description: 'The author\'s name (Default: `Your Name`)',

--- a/command.js
+++ b/command.js
@@ -14,6 +14,9 @@ module.exports = {
     const namespace = options.namespace;
     const platforms = (options.platforms) ? options.platforms.split(',') : options.platforms;
     const overridePrefix = options.overridePrefix;
+    const authorGithub = options.authorGithub;
+    const authorName = options.authorName;
+    const authorEmail = options.authorEmail;
 
     const beforeCreation = Date.now();
     createLibrary({
@@ -24,6 +27,9 @@ module.exports = {
       platforms,
       namespace,
       overridePrefix,
+      authorGithub,
+      authorName,
+      authorEmail
     }).then(() => {
       console.log(`
 ${emoji.get('books')}  Created library ${name} in \`./${name}\`.
@@ -60,5 +66,17 @@ ${emoji.get('arrow_right')}  To get started type \`cd ./${name}\` and run \`npm 
     command: '--platforms <platforms>',
     description: 'Platforms the library will be created for. (comma separated; default: `ios,android,windows`)',
     default: 'ios,android,windows',
+  }, {
+    command: '--author-github [authorGithub]',
+    description: 'The author\'s github name (Default: `github_account_name`)',
+    default: 'github_account_name',    
+  }, {
+    command: '--author-name [authorName]',
+    description: 'The author\'s name (Default: `Your Name`)',
+    default: 'Your Name',    
+  }, {
+    command: '--author-email [authorEmail]',
+    description: 'The author\'s email (Default: `yourname@email.com`)',
+    default: 'yourname@email.com',    
   }]
 };

--- a/lib.js
+++ b/lib.js
@@ -15,6 +15,7 @@ const DEFAULT_OVERRIDE_PREFIX = false;
 const DEFAULT_AUTHOR_GITHUB = 'github_account_name'
 const DEFAULT_AUTHOR_NAME = 'Your Name'
 const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com'
+const DEFAULT_LICENSE = 'Apache-2.0'
 
 module.exports = ({
   namespace,
@@ -27,6 +28,7 @@ module.exports = ({
   authorGithub = DEFAULT_AUTHOR_GITHUB,
   authorName = DEFAULT_AUTHOR_NAME,
   authorEmail = DEFAULT_AUTHOR_EMAIL,
+  license = DEFAULT_LICENSE,
 }) => {
   if (!overridePrefix) {
     if (hasPrefix(name)) {
@@ -73,6 +75,7 @@ module.exports = ({
       authorGithub,
       authorName,
       authorEmail,
+      license,
     };
 
     const filename = path.join(name, template.name(args));

--- a/lib.js
+++ b/lib.js
@@ -12,7 +12,7 @@ const DEFAULT_MODULE_PREFIX = 'react-native';
 const DEFAULT_PACKAGE_IDENTIFIER = 'com.reactlibrary';
 const DEFAULT_PLATFORMS = ['android', 'ios', 'windows'];
 const DEFAULT_OVERRIDE_PREFIX = false;
-const DEFAULT_AUTHOR_GITHUB = 'github_account_name'
+const DEFAULT_GITHUB_ACCOUNT = 'github_account'
 const DEFAULT_AUTHOR_NAME = 'Your Name'
 const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com'
 const DEFAULT_LICENSE = 'Apache-2.0'
@@ -25,7 +25,7 @@ module.exports = ({
   packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
   platforms = DEFAULT_PLATFORMS,
   overridePrefix = DEFAULT_OVERRIDE_PREFIX,
-  authorGithub = DEFAULT_AUTHOR_GITHUB,
+  githubAccount = DEFAULT_GITHUB_ACCOUNT,
   authorName = DEFAULT_AUTHOR_NAME,
   authorEmail = DEFAULT_AUTHOR_EMAIL,
   license = DEFAULT_LICENSE,
@@ -72,7 +72,7 @@ module.exports = ({
       packageIdentifier,
       namespace: namespace || pascalCase(name).split(/(?=[A-Z])/).join('.'),
       platforms,
-      authorGithub,
+      githubAccount,
       authorName,
       authorEmail,
       license,

--- a/lib.js
+++ b/lib.js
@@ -12,6 +12,9 @@ const DEFAULT_MODULE_PREFIX = 'react-native';
 const DEFAULT_PACKAGE_IDENTIFIER = 'com.reactlibrary';
 const DEFAULT_PLATFORMS = ['android', 'ios', 'windows'];
 const DEFAULT_OVERRIDE_PREFIX = false;
+const DEFAULT_AUTHOR_GITHUB = 'github_account_name'
+const DEFAULT_AUTHOR_NAME = 'Your Name'
+const DEFAULT_AUTHOR_EMAIL = 'yourname@email.com'
 
 module.exports = ({
   namespace,
@@ -21,6 +24,9 @@ module.exports = ({
   packageIdentifier = DEFAULT_PACKAGE_IDENTIFIER,
   platforms = DEFAULT_PLATFORMS,
   overridePrefix = DEFAULT_OVERRIDE_PREFIX,
+  authorGithub = DEFAULT_AUTHOR_GITHUB,
+  authorName = DEFAULT_AUTHOR_NAME,
+  authorEmail = DEFAULT_AUTHOR_EMAIL,
 }) => {
   if (!overridePrefix) {
     if (hasPrefix(name)) {
@@ -64,6 +70,9 @@ module.exports = ({
       packageIdentifier,
       namespace: namespace || pascalCase(name).split(/(?=[A-Z])/).join('.'),
       platforms,
+      authorGithub,
+      authorName,
+      authorEmail,
     };
 
     const filename = path.join(name, template.name(args));

--- a/templates/android.js
+++ b/templates/android.js
@@ -34,11 +34,8 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-<<<<<<< HEAD
         // Matches the RN Hello World template
         // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
-=======
->>>>>>> e2d7a55... Adds Support For Generating Maven Package For Android Library
         url "$projectDir/../node_modules/react-native/android"
     }
     mavenCentral()

--- a/templates/android.js
+++ b/templates/android.js
@@ -1,6 +1,6 @@
 module.exports = platform => [{
   name: () => `${platform}/build.gradle`,
-  content: () => `
+  content: ({ packageIdentifier }) => `
 buildscript {
     repositories {
         jcenter()
@@ -14,6 +14,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'maven'
 
 android {
     compileSdkVersion 23
@@ -33,8 +34,11 @@ android {
 repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+<<<<<<< HEAD
         // Matches the RN Hello World template
         // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
+=======
+>>>>>>> e2d7a55... Adds Support For Generating Maven Package For Android Library
         url "$projectDir/../node_modules/react-native/android"
     }
     mavenCentral()
@@ -42,6 +46,77 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
+}
+
+def configureReactNativePom(def pom) {
+    def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
+
+    pom.project {
+        name packageJson.title
+        artifactId packageJson.name
+        version = packageJson.version
+        group = "${packageIdentifier}"
+        description packageJson.description
+        url packageJson.repository.baseUrl
+
+        licenses {
+            license {
+                name packageJson.license
+                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
+                distribution 'repo'
+            }
+        }
+
+        developers {
+            developer {
+                id packageJson.author.username
+                name packageJson.author.name
+            }
+        }
+    }
+}
+
+afterEvaluate { project ->
+
+    task androidJavadoc(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += files(android.bootClasspath)
+        classpath += files(project.getConfigurations().getByName('compile').asList())
+        include '**/*.java'
+    }
+
+    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
+        classifier = 'javadoc'
+        from androidJavadoc.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.srcDirs
+        include '**/*.java'
+    }
+
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        task "jar$\{name\}"(type: Jar, dependsOn: variant.javaCompile) {
+            from variant.javaCompile.destinationDir
+        }
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocJar
+    }
+
+    task installArchives(type: Upload) {
+        configuration = configurations.archives
+        repositories.mavenDeployer {
+            // Deploy to react-native-event-bridge/maven, ready to publish to npm
+            repository url: "file://$\{projectDir\}/../android/maven"
+
+            configureReactNativePom pom
+        }
+    }
 }
   `,
 }, {
@@ -108,4 +183,21 @@ public class ${name}Package implements ReactPackage {
       return Collections.emptyList();
     }
 }`,
-}];
+}, {
+  name: () => `${platform}/README.md`,
+  content: () => `
+README
+======
+
+If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
+
+1. Be sure to have the Android [SDK](https://developer.android.com/studio/index.html) and [NDK](https://developer.android.com/ndk/guides/index.html) installed
+2. Be sure to have a \`local.properties\` file in this folder that points to the Android SDK and NDK
+\`\`\`
+ndk.dir=/Users/{username}/Library/Android/sdk/ndk-bundle
+sdk.dir=/Users/{username}/Library/Android/sdk
+\`\`\`
+3. Delete the \`maven\` folder
+4. Run \`sudo ./gradlew installArchives\`
+5. Verify that latest set of generated files is in the maven folder with the correct version number
+`}];

--- a/templates/general.js
+++ b/templates/general.js
@@ -73,7 +73,7 @@ ${name};
   },
 }, {
   name: () => 'package.json',
-  content: ({ moduleName, platforms, authorGithub, authorName, authorEmail }) => {
+  content: ({ moduleName, platforms, authorGithub, authorName, authorEmail, license }) => {
     let dependencies = `
     "react": "16.0.0-alpha.6",
     "react-native": "^0.44.1"`;
@@ -105,7 +105,7 @@ ${name};
     "name": "${authorName}",
     "email": "${authorEmail}"
   },
-  "license": "Apache-2.0",
+  "license": "${license}",
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {

--- a/templates/general.js
+++ b/templates/general.js
@@ -73,7 +73,7 @@ ${name};
   },
 }, {
   name: () => 'package.json',
-  content: ({ moduleName, platforms, authorGithub, authorName, authorEmail, license }) => {
+  content: ({ moduleName, platforms, githubAccount, authorName, authorEmail, license }) => {
     let dependencies = `
     "react": "16.0.0-alpha.6",
     "react-native": "^0.44.1"`;
@@ -94,14 +94,13 @@ ${name};
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/${authorGithub}/${moduleName}.git",
-    "baseUrl": "https://github.com/${authorGithub}/${moduleName}"
+    "url": "git+https://github.com/${githubAccount}/${moduleName}.git",
+    "baseUrl": "https://github.com/${githubAccount}/${moduleName}"
   },
   "keywords": [
     "react-native"
   ],
   "author": {
-    "username": "${authorGithub}",
     "name": "${authorName}",
     "email": "${authorEmail}"
   },

--- a/templates/general.js
+++ b/templates/general.js
@@ -73,7 +73,7 @@ ${name};
   },
 }, {
   name: () => 'package.json',
-  content: ({ moduleName, platforms }) => {
+  content: ({ moduleName, platforms, authorGithub, authorName, authorEmail }) => {
     let dependencies = `
     "react": "16.0.0-alpha.6",
     "react-native": "^0.44.1"`;
@@ -94,16 +94,16 @@ ${name};
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/github_account_name/${moduleName}.git",
-    "baseUrl": "https://github.com/github_account_name/${moduleName}"
+    "url": "git+https://github.com/${authorGithub}/${moduleName}.git",
+    "baseUrl": "https://github.com/${authorGithub}/${moduleName}"
   },
   "keywords": [
     "react-native"
   ],
   "author": {
-    "username": "your_username",
-    "name": "Your Name",
-    "email": "your_name@email.com"
+    "username": "${authorGithub}",
+    "name": "${authorName}",
+    "email": "${authorEmail}"
   },
   "license": "Apache-2.0",
   "licenseFilename": "LICENSE",

--- a/templates/general.js
+++ b/templates/general.js
@@ -85,17 +85,29 @@ ${name};
     return `
 {
   "name": "${moduleName}",
+  "title": "${moduleName.split('-').map(word => word[0].toUpperCase() + word.substr(1)).join(' ')}",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \\"Error: no test specified\\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/github_account_name/${moduleName}.git",
+    "baseUrl": "https://github.com/github_account_name/${moduleName}"
+  },
   "keywords": [
     "react-native"
   ],
-  "author": "",
-  "license": "",
+  "author": {
+    "username": "your_username",
+    "name": "Your Name",
+    "email": "your_name@email.com"
+  },
+  "license": "Apache-2.0",
+  "licenseFilename": "LICENSE",
+  "readmeFilename": "README.md",
   "peerDependencies": {
     ${dependencies}
   },


### PR DESCRIPTION
Summary:
This adds support for generating the maven package similar to how
React Native core does it.
This allows a brownfield Android project reference this maven package
instead of the project in the node_modules.

This also adds a few new fields to `package.json`. Do y'all think it's okay to have placeholder values or should I add the ability to provide them to the cli? 