### PR TITLE
[Android] Fixes Up the Gradle Version And RN Maven Path

### DIFF
--- a/templates/android.js
+++ b/templates/android.js
@@ -7,7 +7,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        // Matches the RN Hello World template
+        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L8
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 
@@ -29,6 +31,12 @@ android {
 }
 
 repositories {
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        // Matches the RN Hello World template
+        // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L21
+        url "$projectDir/../node_modules/react-native/android"
+    }
     mavenCentral()
 }
 


### PR DESCRIPTION
Summary:
I believe starting with RN 21 (maybe), the dependencies are no longer
on maven / mavencentral but instead you reference them from the
local node_modules folder.
Second in order to make the Android lib project work with AS, we have
to bump the gradle version. It now matches the version in the RN hello world project.

#51 & #39 - both have make too many folder level jumps. The `node_modules` folder from the perspective of the android lib project is only one up. 