### PR TITLE
Fix filename in Android installation guide

### DIFF
--- a/templates/general.js
+++ b/templates/general.js
@@ -20,7 +20,7 @@ module.exports = [{
       manualInstallation += `
 #### Android
 
-1. Open up \`android/app/src/main/java/[...]/MainActivity.java\`
+1. Open up \`android/app/src/main/java/[...]/MainApplication.java\`
   - Add \`import ${packageIdentifier}.${name}Package;\` to the imports at the top of the file
   - Add \`new ${name}Package()\` to the list returned by the \`getPackages()\` method
 2. Append the following lines to \`android/settings.gradle\`:


### PR DESCRIPTION
We had an [issue](https://github.com/FormidableLabs/react-native-app-auth/issues/85) raised to point out that the instructions in the manual installation of the Android app talk about `MainActivity.java` when it should be `MainApplication.java`.

I never noticed it, but looks like they're right! So here's a PR to also fix it for the template.