### PR TITLE
Fix creating and building example and cleanup code around it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
 node_modules
 npm-debug.log
-
-example

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "homepage": "https://github.com/frostney/react-native-create-library#readme",
   "dependencies": {
     "commander": "^2.9.0",
+    "jsonfile": "^4.0.0",
     "mkdirp": "^0.5.1",
     "node-emoji": "^1.5.1",
     "param-case": "^2.1.0",

--- a/templates/android.js
+++ b/templates/android.js
@@ -1,7 +1,6 @@
 module.exports = platform => [{
   name: () => `${platform}/build.gradle`,
-  content: ({ packageIdentifier }) => `
-buildscript {
+  content: ({ packageIdentifier }) => `buildscript {
     repositories {
         jcenter()
     }
@@ -115,20 +114,18 @@ afterEvaluate { project ->
         }
     }
 }
-  `,
+`,
 }, {
   name: () => `${platform}/src/main/AndroidManifest.xml`,
-  content: ({ packageIdentifier }) => `
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  content: ({ packageIdentifier }) => `<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="${packageIdentifier}">
 
 </manifest>
-  `,
+`,
 }, {
   name: ({ packageIdentifier, name }) =>
     `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${name}Module.java`,
-  content: ({ packageIdentifier, name }) => `
-package ${packageIdentifier};
+  content: ({ packageIdentifier, name }) => `package ${packageIdentifier};
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -157,8 +154,7 @@ public class ${name}Module extends ReactContextBaseJavaModule {
 }, {
   name: ({ packageIdentifier, name }) =>
     `${platform}/src/main/java/${packageIdentifier.split('.').join('/')}/${name}Package.java`,
-  content: ({ packageIdentifier, name }) => `
-package ${packageIdentifier};
+  content: ({ packageIdentifier, name }) => `package ${packageIdentifier};
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -184,11 +180,11 @@ public class ${name}Package implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
-}`,
+}
+`,
 }, {
   name: () => `${platform}/README.md`,
-  content: () => `
-README
+  content: () => `README
 ======
 
 If you want to publish the lib as a maven dependency, follow these steps before publishing a new version to npm:
@@ -202,4 +198,5 @@ sdk.dir=/Users/{username}/Library/Android/sdk
 3. Delete the \`maven\` folder
 4. Run \`sudo ./gradlew installArchives\`
 5. Verify that latest set of generated files is in the maven folder with the correct version number
-`}];
+`
+}];

--- a/templates/example.js
+++ b/templates/example.js
@@ -1,0 +1,112 @@
+/* eslint max-len: 0 */
+
+module.exports = [{
+  name: () => 'scripts/examples_postinstall.js',
+  content: () =>
+`#!/usr/bin/env node
+
+  /*
+   * Using libraries within examples and linking them within packages.json like:
+   * "react-native-library-name": "file:../"
+   * will cause problems with the metro bundler if the example will run via
+   * \`react-native run-[ios|android]\`. This will result in an error as the metro
+   * bundler will find multiple versions for the same module while resolving it.
+   * The reason for that is that if the library is installed it also copies in the
+   * example folder itself as well as the node_modules folder of the library
+   * although their are defined in .npmignore and should be ignored in theory.
+   *
+   * This postinstall script removes the node_modules folder as well as all
+   * entries from the libraries .npmignore file within the examples node_modules
+   * folder after the library was installed. This should resolve the metro
+   * bundler issue mentioned above.
+   *
+   * It is expected this scripts lives in the libraries root folder within a
+   * scripts folder. As first parameter the relative path to the libraries
+   * folder within the examples node_modules folder should be provided.
+   * An example's package.json entry could look like:
+   * "postinstall": "node ../scripts/examples_postinstall.js node_modules/react-native-library-name/"
+   */
+
+  'use strict';
+
+  const fs = require('fs');
+  const path = require('path');
+
+  /// Delete all files and directories for the given path
+  const removeFileDirectoryRecursively = fileDirPath => {
+    // Remove file
+    if (!fs.lstatSync(fileDirPath).isDirectory()) {
+      fs.unlinkSync(fileDirPath);
+      return;
+    }
+
+    // Go down the directory an remove each file / directory recursively
+    fs.readdirSync(fileDirPath).forEach(entry => {
+      const entryPath = path.join(fileDirPath, entry);
+      removeFileDirectoryRecursively(entryPath);
+    });
+    fs.rmdirSync(fileDirPath);
+  };
+
+  /// Remove example/node_modules/react-native-library-name/node_modules directory
+  const removeLibraryNodeModulesPath = (libraryNodeModulesPath) => {
+    const nodeModulesPath = path.resolve(libraryNodeModulesPath, 'node_modules')
+
+    if (!fs.existsSync(nodeModulesPath)) {
+      console.log(\`No node_modules path found at \${nodeModulesPath}. Skipping delete.\`)
+      return;
+    }
+
+    console.log(\`Deleting: \${nodeModulesPath}\`)
+    try {
+      removeFileDirectoryRecursively(nodeModulesPath);
+      console.log(\`Successfully deleted: \${nodeModulesPath}\`)
+    } catch (err) {
+      console.log(\`Error deleting \${nodeModulesPath}: \${err.message}\`);
+    }
+  };
+
+  /// Remove all entries from the .npmignore within  example/node_modules/react-native-library-name/
+  const removeLibraryNpmIgnorePaths = (npmIgnorePath, libraryNodeModulesPath) => {
+    if (!fs.existsSync(npmIgnorePath)) {
+      console.log(\`No .npmignore path found at \${npmIgnorePath}. Skipping deleting content.\`);
+      return;
+    }
+
+    fs.readFileSync(npmIgnorePath, 'utf8').split(/\\r?\\n/).forEach(entry => {
+      if (entry.length === 0) {
+        return
+      }
+
+      const npmIgnoreLibraryNodeModulesEntryPath = path.resolve(libraryNodeModulesPath, entry);
+      if (!fs.existsSync(npmIgnoreLibraryNodeModulesEntryPath)) {
+        return;
+      }
+
+      console.log(\`Deleting: \${npmIgnoreLibraryNodeModulesEntryPath}\`)
+      try {
+        removeFileDirectoryRecursively(npmIgnoreLibraryNodeModulesEntryPath);
+        console.log(\`Successfully deleted: \${npmIgnoreLibraryNodeModulesEntryPath}\`)
+      } catch (err) {
+        console.log(\`Error deleting \${npmIgnoreLibraryNodeModulesEntryPath}: \${err.message}\`);
+      }
+    });
+  };
+
+  // Main start sweeping process
+  (() => {
+    // Read out dir of example project
+    const exampleDir = process.cwd();
+
+    // Relative libraries path within the examples node_modules directory
+    const relativeLibraryNodeModulesPath = process.argv[2];
+    const libraryNodeModulesPath = path.resolve(exampleDir, relativeLibraryNodeModulesPath);
+
+
+    removeLibraryNodeModulesPath(libraryNodeModulesPath);
+
+    const npmIgnorePath = path.resolve(__dirname, '../.npmignore');
+    removeLibraryNpmIgnorePaths(npmIgnorePath, libraryNodeModulesPath);
+  })();
+`
+}];

--- a/templates/general.js
+++ b/templates/general.js
@@ -47,8 +47,7 @@ module.exports = [{
 `;
     }
 
-    return `
-# ${moduleName}
+    return `# ${moduleName}
 
 ## Getting started
 
@@ -82,8 +81,7 @@ ${name};
     "react-native-windows": "0.52.0"
 `;
     }
-    return `
-{
+    return `{
   "name": "${moduleName}",
   "title": "${moduleName.split('-').map(word => word[0].toUpperCase() + word.substr(1)).join(' ')}",
   "version": "1.0.0",
@@ -118,8 +116,7 @@ ${name};
   },
 }, {
   name: () => 'index.js',
-  content: ({ name }) => `
-import { NativeModules } from 'react-native';
+  content: ({ name }) =>`import { NativeModules } from 'react-native';
 
 const { ${name} } = NativeModules;
 
@@ -128,8 +125,7 @@ export default ${name};
 }, {
   name: () => '.gitignore',
   content: ({ platforms }) => {
-    let content = `
-# OSX
+    let content =`# OSX
 #
 .DS_Store
 
@@ -138,7 +134,7 @@ export default ${name};
 node_modules/
 npm-debug.log
 yarn-error.log
-  `;
+`;
 
     if (platforms.indexOf('ios') >= 0) {
       content += `
@@ -162,7 +158,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-      `;
+`;
     }
 
     if (platforms.indexOf('android') >= 0) {
@@ -180,7 +176,7 @@ local.properties
 buck-out/
 \\.buckd/
 *.keystore
-      `;
+`;
     }
 
     return content;
@@ -189,7 +185,16 @@ buck-out/
   name: () => '.gitattributes',
   content: ({ platforms }) => {
     if (platforms.indexOf('ios') >= 0) {
-      return '*.pbxproj -text';
+      return '*.pbxproj -text\n';
+    }
+
+    return '';
+  }
+}, {
+  name: () => '.npmignore',
+  content: ({ generateExample }) => {
+    if (generateExample) {
+      return 'example\n';
     }
 
     return '';

--- a/templates/index.js
+++ b/templates/index.js
@@ -10,5 +10,5 @@ module.exports = [].concat(
   general,
   android.map(updatePlatformInFile('android')),
   ios.map(updatePlatformInFile('ios')),
-  windows.map(updatePlatformInFile('windows'))
+  windows.map(updatePlatformInFile('windows')),
 );

--- a/templates/ios.js
+++ b/templates/ios.js
@@ -27,12 +27,10 @@ Pod::Spec.new do |s|
   #s.dependency "others"
 end
 
-  `,
+`,
 }, {
-
   name: ({ name }) => `${platform}/${name}.h`,
-  content: ({ name }) => `
-#if __has_include(<React/RCTBridgeModule.h>)
+  content: ({ name }) => `#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
 #else
 #import "RCTBridgeModule.h"
@@ -41,11 +39,10 @@ end
 @interface ${name} : NSObject <RCTBridgeModule>
 
 @end
-  `,
+`,
 }, {
   name: ({ name }) => `${platform}/${name}.m`,
-  content: ({ name }) => `
-#import "${name}.h"
+  content: ({ name }) => `#import "${name}.h"
 
 @implementation ${name}
 
@@ -62,7 +59,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
 }
 
 @end
-  `,
+`,
 }, {
   name: ({ name }) => `${platform}/${name}.xcworkspace/contents.xcworkspacedata`,
   content: ({ name }) => `<?xml version="1.0" encoding="UTF-8"?>
@@ -72,7 +69,7 @@ RCT_EXPORT_METHOD(sampleMethod:(NSString *)stringArgument numberParameter:(nonnu
       location = "group:${name}.xcodeproj">
    </FileRef>
 </Workspace>
-  `,
+`,
 }, {
   name: ({ name }) => `${platform}/${name}.xcodeproj/project.pbxproj`,
   content: ({ name }) => `// !$*UTF8*$!

--- a/templates/windows.js
+++ b/templates/windows.js
@@ -86,7 +86,7 @@ Global
 		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x64.ActiveCfg = Release|x64
 		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x64.Build.0 = Release|x64
 		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x86.ActiveCfg = Release|Win32
-		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x86.Build.0 = Release|Win32    
+		{4B72C796-16D5-4E3A-81C0-3E36F531E578}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/utils/exec.js
+++ b/utils/exec.js
@@ -1,0 +1,13 @@
+var cp = require('child_process');
+
+module.exports = (command, options) => {
+  return new Promise((resolve, reject) => {
+    try {
+      // We use execSync in here to be able to output the stdout to standard out
+      const stdout = cp.execSync(command, options);
+      return resolve(stdout);
+    } catch (e) {
+      return reject(e);
+    }
+  });
+};

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,9 +1,13 @@
 const hasPrefix = require('./hasPrefix');
 const createFile = require('./createFile');
 const createFolder = require('./createFolder');
+const npmAddScriptSync = require('./npmAddScriptSync');
+const exec = require('./exec');
 
 module.exports = {
   hasPrefix,
   createFile,
   createFolder,
+  npmAddScriptSync,
+  exec,
 };

--- a/utils/npmAddScriptSync.js
+++ b/utils/npmAddScriptSync.js
@@ -1,0 +1,21 @@
+const jsonfile = require('jsonfile')
+
+// Add a script entry to a package.json file at the packageJsonPath.
+// The script parameter shoud be of {key: key, value: value}
+module.exports = (packageJsonPath, script) => {
+  try {
+    var packageJson = jsonfile.readFileSync(packageJsonPath);
+    if (!packageJson.scripts) packageJson.scripts = {};
+    if (!script.force && packageJson.scripts[script.key]) {
+      throw new Error(`That script entry for key: ${script.key} already exists.`);
+    }
+    packageJson.scripts[script.key] = script.value;
+    jsonfile.writeFileSync(packageJsonPath, packageJson, {spaces: 2});
+  } catch (e) {
+    if (e.message === 'ENOENT, no such file or directory \'package.json\'') {
+      throw new Error(`The package.json at path: ${packageJsonPath} does not exist.`);
+    } else {
+      throw e;
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,7 +562,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -716,6 +716,12 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
     jsonify "~0.0.0"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This PR fixes running examples within libraries which didn't work before as the metro bundler was confused of multiple modules. The reason for that is that if we link the library via `library-name: file:..` within the `package.json` of the example the `node_modules` folder of this library get's copied too what causes a multiple modules error at the end if react native tries to run.

This PR is adding a script to the library and executes it after running `npm / yarn install` within the example. The script looks into the `node_modules` folder of the example for the library and removes the `node_modules` within that libraries folder.

Fixes #69