### PR TITLE
Add `-p` alias to `--prefix`

### DIFF
--- a/command.js
+++ b/command.js
@@ -48,7 +48,7 @@ ${emoji.get('arrow_right')}  To get started type \`cd ./${name}\` and run \`npm 
     });
   },
   options: [{
-    command: '--prefix [prefix]',
+    command: '-p, --prefix [prefix]',
     description: 'The prefix for the library (Default: `RN`)',
     default: 'RN',
   }, {


### PR DESCRIPTION
Fixes #84 

The documentation states `--prefix` can be also used as `-p`, but that wasn't the case. This PR fixes this issue.